### PR TITLE
Replace illegal filename characters with underscore

### DIFF
--- a/iviewdl/iviewdl.py
+++ b/iviewdl/iviewdl.py
@@ -31,7 +31,7 @@ def fix_stream_url(url):
 def get_stream_urls(data):
     if data["playlist"]:
         out = {}
-        out["filename"] = "{} {}.mp4".format(data["seriesTitle"], data["title"])
+        out["filename"] = "".join(c if c not in "\/:*?<>|" else "_" for c in "{} {}.mp4".format(data["seriesTitle"], data["title"]))
         for p in data["playlist"]:
             if p["type"] == "program":
                 out["program"] = fix_stream_url(p["hls-high"])


### PR DESCRIPTION
Now it works with programs like Media Watch that have the date (including forward slashes) in the program title.