### PR TITLE
Support to batch download videos specified in a file

### DIFF
--- a/iviewdl/iviewdl.py
+++ b/iviewdl/iviewdl.py
@@ -18,9 +18,7 @@ if not find_executable("ffmpeg"):
 TOKEN = Soup(requests.get("http://iview.abc.net.au/auth").text, "lxml").find("tokenhd").text
 
 def search(term):
-    results = requests.get("http://iview.abc.net.au/api/search/", params={"fields": "href,seriesTitle,title", "keyword": term}).json()
-    print(results)
-    return results
+    return requests.get("http://iview.abc.net.au/api/search/", params={"fields": "href,seriesTitle,title", "keyword": term}).json()
 
 def vtt_to_srt(url):
     vtt = requests.get(url).text.strip()

--- a/iviewdl/iviewdl.py
+++ b/iviewdl/iviewdl.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from distutils.spawn import find_executable
 import re
 import sys
+import os
 from tempfile import NamedTemporaryFile
 
 from bs4 import BeautifulSoup as Soup
@@ -17,7 +18,9 @@ if not find_executable("ffmpeg"):
 TOKEN = Soup(requests.get("http://iview.abc.net.au/auth").text, "lxml").find("tokenhd").text
 
 def search(term):
-    return requests.get("http://iview.abc.net.au/api/search/", params={"fields": "href,seriesTitle,title", "keyword": term}).json()
+    results = requests.get("http://iview.abc.net.au/api/search/", params={"fields": "href,seriesTitle,title", "keyword": term}).json()
+    print(results)
+    return results
 
 def vtt_to_srt(url):
     vtt = requests.get(url).text.strip()
@@ -83,23 +86,55 @@ def main():
     parser.add_argument("-s", "--selection", help="Number of video to get", type=int)
     parser.add_argument("-f", "--filename")
     args = parser.parse_args()
-    results = search(args.search)
-    if len(results) > 1:
-        if args.selection is None:
-            print("\n".join("{0}: {seriesTitle} {title}".format(n, **data) for n,data in enumerate(results)))
-            if sys.stdout.isatty():
-                result = results[prompt("enter your choice: ")]
-            else:
-                return 2
-        else:
-            result = results[args.selection]
+
+    if os.path.isfile(args.search):
+        process_exit_status = []
+        workers = []
+
+        with open(args.search, "r") as videos:
+            for line in videos:
+                try:
+                    episode_name, series_name, iview_id = \
+                        [elem.strip() for elem in line.split(",")]
+
+                    if not episode_name or not series_name or not iview_id:
+                        raise Exception
+
+                    print("Downloading {} {}".format(series_name, episode_name), file=sys.stdout)
+                    data = get_stream_urls(requests.get("http://iview.abc.net.au/api/programs/" + iview_id).json())
+                    workers.append(subprocess.Popen(get_download_cmd(data, filename=episode_name), stdout=subprocess.PIPE))
+                except:
+                    print("Could not start download of {}".format(line))
+                    continue
+
+        for worker in workers:
+            worker.wait()
+            process_exit_status.append(worker.returncode)
+
+        try:
+            return max(process_exit_status)
+        except:
+            return 1
+
     else:
-        result = results[0]
-    print("Downloading {seriesTitle} {title}".format(**result), file=sys.stdout)
-    data = get_stream_urls(requests.get("http://iview.abc.net.au/api/" + result["href"]).json())
-    process = subprocess.Popen(get_download_cmd(data, filename=args.filename), stdout=subprocess.PIPE)
-    process.wait()
-    return process.returncode
+        results = search(args.search)
+        if len(results) > 1:
+            if True:
+                print("\n".join("{0}: {seriesTitle} {title}".format(n, **data) for n,data in enumerate(results)))
+                if sys.stdout.isatty():
+                    result = results[prompt("enter your choice: ")]
+                else:
+                    return 2
+            else:
+                result = results[args.selection]
+        else:
+            result = results[0]
+
+        print("Downloading {seriesTitle} {title}".format(**result), file=sys.stdout)
+        data = get_stream_urls(requests.get("http://iview.abc.net.au/api/" + result["href"]).json())
+        process = subprocess.Popen(get_download_cmd(data, filename=args.filename), stdout=subprocess.PIPE)
+        process.wait()
+        return process.returncode
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Support to specify videos in a file to download, to get around iview api not returning all available videos.

Supply path to a text file as the launch argument with one video per line, specified as SERIES_NAME/IVIEW_VIDEO_ID.

Series name is the series name that would be returned by the iview api.
iview Video Id is the last element of the URL for any particular video (e.g. http://iview.abc.net.au/programs/utopia/CO1511V007S00 iview id is CO1511V007S00)