### PR TITLE
Fix errors on series with ';' in their descriptions

### DIFF
--- a/new_iviewdl.py
+++ b/new_iviewdl.py
@@ -18,7 +18,7 @@ def main():
     if "/video/" in args.seriesurl:
         download_url_list([args.seriesurl])
     else:
-        page = urlopen(args.seriesurl).read().split(b"window.__INITIAL_STATE__ = ",1)[1].split(b";")[0]
+        page = urlopen(args.seriesurl).read().split(b"window.__INITIAL_STATE__ = ",1)[1].split(b"</script")[0].rstrip().rstrip(";")
         data = json.loads(eval(page))
         download_url_list([ep["shareUrl"] for ep in data["page"]["pageData"]["_embedded"]["selectedSeries"]["_embedded"]["videoEpisodes"]])
 


### PR DESCRIPTION
Some series have a ';' in their descriptions so when the split is made it breaks the JSON string early and throws an error:
`[root@lykke iView]# ./new_iviewdl.py https://iview.abc.net.au/show/gardening-australia/series/29
Traceback (most recent call last):
  File "./new_iviewdl.py", line 27, in <module>
    main()
  File "./new_iviewdl.py", line 22, in main
    data = json.loads(eval(page))
  File "<string>", line 1
   ...output ommited...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ^
SyntaxError: EOL while scanning string literal
`

By splitting at the end of the script instead, then cleaning up the tail of the JSON string, we are left with a valid JSON string which parses correctly.

Some example of the series that contain a semicolon in their episode descriptions are:
https://iview.abc.net.au/show/gardening-australia/series/29